### PR TITLE
fix: 🐛 Fixed storage dye recipe to always have a result of stack of 1…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.18.2
-forge_version=40.0.12
-mod_version=0.0.6
+forge_version=40.1.17
+mod_version=0.0.7
 jei_mc_version=1.18.2
 jei_version=9.7.0+
 patchouli_version=1.18.2-66

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/crafting/StorageDyeRecipeBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/crafting/StorageDyeRecipeBase.java
@@ -78,6 +78,7 @@ public abstract class StorageDyeRecipeBase extends CustomRecipe {
 		}
 
 		ItemStack coloredStorage = columnStorage.getB().copy();
+		coloredStorage.setCount(1);
 		int storageColumn = columnStorage.getA();
 
 		applyTintColors(columnDyes, coloredStorage, storageColumn);


### PR DESCRIPTION
… to prevent dupe bug when applying dyes to storage stacks of more than 1.