### PR TITLE
fix: 🐛 Moved initialization of world in RecipeHelper to core to stop …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.18.2
 forge_version=40.1.17
-mod_version=0.3.6
+mod_version=0.3.7
 jei_mc_version=1.18.2
 jei_version=9.7.0+
 patchouli_version=1.18.2-66

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/SophisticatedCore.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/SophisticatedCore.java
@@ -1,12 +1,15 @@
 package net.p3pp3rf1y.sophisticatedcore;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -22,6 +25,7 @@ import net.p3pp3rf1y.sophisticatedcore.crafting.UpgradeNextTierRecipe;
 import net.p3pp3rf1y.sophisticatedcore.data.DataGenerators;
 import net.p3pp3rf1y.sophisticatedcore.init.ModCompat;
 import net.p3pp3rf1y.sophisticatedcore.network.PacketHandler;
+import net.p3pp3rf1y.sophisticatedcore.util.RecipeHelper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,7 +50,16 @@ public class SophisticatedCore {
 		modBus.addListener(DataGenerators::gatherData);
 		modBus.addGenericListener(RecipeSerializer.class, this::registerRecipeSerializers);
 
-		MinecraftForge.EVENT_BUS.addListener(SophisticatedCore::onResourceReload);
+		IEventBus eventBus = MinecraftForge.EVENT_BUS;
+		eventBus.addListener(SophisticatedCore::onResourceReload);
+		eventBus.addListener(SophisticatedCore::serverStarted);
+	}
+
+	private static void serverStarted(ServerStartedEvent event) {
+		ServerLevel world = event.getServer().getLevel(Level.OVERWORLD);
+		if (world != null) {
+			RecipeHelper.setWorld(world);
+		}
 	}
 
 	private void registerRecipeSerializers(RegistryEvent.Register<RecipeSerializer<?>> evt) {


### PR DESCRIPTION
…crashes with compacting upgrade or cooking upgrades when only Sophisticated Storage is included in the pack