### PR TITLE
fix: 🐛 Fixed to only reload upgrade tabs (and because of that close t…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.1.24
-mod_version=0.5.37
+mod_version=0.5.38
 jei_mc_version=1.19.1-forge
 jei_version=11.2.0.244
 patchouli_version=1.18.2-66

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
@@ -315,7 +315,7 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 			}
 		}
 
-		if (upgradeChanged) {
+		if (upgradeChanged && checkUpgradeControlNeedsReload()) {
 			reloadUpgradeControl();
 		}
 
@@ -330,6 +330,18 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 		storageWrapper.setPersistent(true);
 		storageWrapper.getInventoryHandler().saveInventory();
 		storageWrapper.getUpgradeHandler().saveInventory();
+	}
+
+	private boolean checkUpgradeControlNeedsReload() {
+		for (Map.Entry<Integer, IUpgradeWrapper> entry : storageWrapper.getUpgradeHandler().getSlotWrappers().entrySet()) {
+			Integer slot = entry.getKey();
+			IUpgradeWrapper slotWrapper = entry.getValue();
+			if(UpgradeContainerRegistry.instantiateContainer(player, slot, slotWrapper)
+					.map(newContainer -> !upgradeContainers.containsKey(slot) || upgradeContainers.get(slot).getSlots().size() != newContainer.getSlots().size()).orElse(false)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	protected boolean isUpgradeSettingsSlot(int index) {


### PR DESCRIPTION
…hem) when the number of slots synced from server is different than the one on the client