### PR TITLE
fix: 🐛 Fix void upgrade in limited barrel to only delete items that m…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.7
-mod_version=0.5.67
+mod_version=0.5.68
 jei_mc_version=1.19.1-forge
 jei_version=11.2.0.244
 patchouli_version=1.18.2-66

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandler.java
@@ -283,7 +283,11 @@ public abstract class InventoryHandler extends ItemStackHandler implements ITrac
 	@Nonnull
 	public ItemStack insertItemOnlyToSlot(int slot, ItemStack stack, boolean simulate) {
 		initSlotTracker();
-		return triggerOverflowUpgrades(insertItemInternal(slot, stack, simulate));
+		if (ItemHandlerHelper.canItemStacksStack(getStackInSlot(slot), stack)) {
+			return triggerOverflowUpgrades(insertItemInternal(slot, stack, simulate));
+		}
+
+		return stack;
 	}
 
 	private void initSlotTracker() {


### PR DESCRIPTION
…atch the slot that was manually deposited into and to keep other items in players hand without removing them