### PR TITLE
1.19.x Add deleteItems function to InventoryHelper to support flushing an inventory without dropping items

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.13
-mod_version=0.5.111
+mod_version=0.5.112
 jei_mc_version=1.19.2-forge
 jei_version=11.6.0.1018
 patchouli_version=1.18.2-66

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/CountAbbreviator.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/CountAbbreviator.java
@@ -2,18 +2,21 @@ package net.p3pp3rf1y.sophisticatedcore.util;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 public class CountAbbreviator {
 	private CountAbbreviator() {}
 
 	private static final String[] COUNT_SUFFIXES = new String[] {"k", "m", "b"};
+	private static final DecimalFormatSymbols ROOT_LOCALE_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ROOT);
 	private static final DecimalFormat TWO_DIGIT_PRECISION;
 	private static final DecimalFormat ONE_DIGIT_PRECISION;
 
 	static {
-		TWO_DIGIT_PRECISION = new DecimalFormat("#.00");
+		TWO_DIGIT_PRECISION = new DecimalFormat("#.00", ROOT_LOCALE_FORMAT_SYMBOLS);
 		TWO_DIGIT_PRECISION.setRoundingMode(RoundingMode.DOWN);
-		ONE_DIGIT_PRECISION = new DecimalFormat("##.0");
+		ONE_DIGIT_PRECISION = new DecimalFormat("##.0", ROOT_LOCALE_FORMAT_SYMBOLS);
 		ONE_DIGIT_PRECISION.setRoundingMode(RoundingMode.DOWN);
 	}
 
@@ -25,7 +28,7 @@ public class CountAbbreviator {
 	public static String abbreviate(int count, int maxCharacters) {
 		int digits = (int) Math.log10(count) + 1;
 		if (digits <= maxCharacters) {
-			return String.format("%,d", count);
+			return String.format(Locale.ROOT, "%,d", count);
 		}
 
 		int thousandsExponent = ((digits - maxCharacters) / 3) + 1;
@@ -38,7 +41,7 @@ public class CountAbbreviator {
 
 		String numberPart = "";
 		if (wholeDigits > 3 || precisionDigits == 0) {
-			numberPart = String.format("%,d", (int) divisionResult);
+			numberPart = String.format(Locale.ROOT, "%,d", (int) divisionResult);
 		} else if (precisionDigits == 2) {
 			numberPart = TWO_DIGIT_PRECISION.format(divisionResult);
 		} else if (precisionDigits == 1) {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/InventoryHelper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/InventoryHelper.java
@@ -406,6 +406,15 @@ public class InventoryHelper {
 		});
 	}
 
+	public static void deleteItems(ItemStackHandler inventoryHandler) {
+		iterate(inventoryHandler, (slot, stack) -> {
+			if (stack.isEmpty()) {
+				return;
+			}
+			inventoryHandler.setStackInSlot(slot, ItemStack.EMPTY);
+		});
+	}
+
 	public static int getAnalogOutputSignal(ITrackedContentsItemHandler handler) {
 		AtomicDouble totalFilled = new AtomicDouble(0);
 		AtomicBoolean isEmpty = new AtomicBoolean(true);


### PR DESCRIPTION
Adds a deleteItems iterator function similar to dropItems that instead
of dropping the items, it just deletes them. This is to support a
Clearable implementation on Sophisticated Storage inventories so that
other mods can explicitly clear the contents of an inventory before
destroying the inventory block entity.

Addresses: https://github.com/P3pp3rF1y/SophisticatedStorage/issues/335

SophisticatedStorage PR: https://github.com/P3pp3rF1y/SophisticatedStorage/pull/336