### PR TITLE
feat: ✨ Add Storage IO blocks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedcore
 mod_group_id=sophisticatedcore
-mod_version=0.6.8
+mod_version=0.6.9
 sonar_project_key=sophisticatedcore:SophisticatedCore
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedCore
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/controller/IControllableStorage.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/controller/IControllableStorage.java
@@ -1,7 +1,6 @@
 package net.p3pp3rf1y.sophisticatedcore.controller;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.p3pp3rf1y.sophisticatedcore.api.IStorageWrapper;
 import net.p3pp3rf1y.sophisticatedcore.settings.memory.MemorySettingsCategory;
@@ -11,16 +10,11 @@ public interface IControllableStorage extends IControllerBoundable {
 
 	IStorageWrapper getStorageWrapper();
 
-	default boolean canBeConnected() {
-		return getControllerPos().isEmpty();
-	}
-
-	default boolean hasStorageData() {
+	default boolean canConnectStorages() {
 		return true;
 	}
 
-	@Override
-	default boolean canConnectStorages() {
+	default boolean hasStorageData() {
 		return true;
 	}
 
@@ -36,28 +30,8 @@ public interface IControllableStorage extends IControllerBoundable {
 		}
 	}
 
-	private void addToAdjacentController() {
-		Level level = getStorageBlockLevel();
-		if (!level.isClientSide()) {
-			BlockPos pos = getStorageBlockPos();
-			for (Direction dir : Direction.values()) {
-				BlockPos offsetPos = pos.offset(dir.getNormal());
-				WorldHelper.getBlockEntity(level, offsetPos, IControllerBoundable.class).ifPresentOrElse(
-						s -> {
-							if (s.canConnectStorages()) {
-								s.getControllerPos().ifPresent(controllerPos -> addToController(level, pos, controllerPos));
-							}
-						},
-						() -> addToController(level, pos, offsetPos)
-				);
-				if (getControllerPos().isPresent()) {
-					break;
-				}
-			}
-		}
-	}
-
-	private void addToController(Level level, BlockPos pos, BlockPos controllerPos) {
+	@Override
+	default void addToController(Level level, BlockPos pos, BlockPos controllerPos) {
 		WorldHelper.getBlockEntity(level, controllerPos, ControllerBlockEntityBase.class).ifPresent(c -> c.addStorage(pos));
 	}
 


### PR DESCRIPTION
- Storage IO when placed in controller's multiblock allows input / outputing items from its sides
- Storage Input is similar to IO, but only allows piping items into the multiblock. Is very optimized and preferred way to pipe items into multiblock especially in cases where there's a lot piped and even more when the storage could be getting full and there are still items to pipe in
- Storage Output is similar to IO again, only allows to output items
- None of these connect other blocks to the storage multiblock so there can be another storage on their side that pushes / pulls items to / from multiblock using hopper upgrade
- Storage controller changed to be inline with IO blocks Thanks Ridanisaurus for all the new textures