### PR TITLE
fix: 🐛 Fixed backpack to just close gui instead of crashing out of wo…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedcore
 mod_group_id=sophisticatedcore
-mod_version=0.6.29
+mod_version=0.6.30
 sonar_project_key=sophisticatedcore:SophisticatedCore
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedCore
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
@@ -33,6 +33,7 @@ import net.p3pp3rf1y.sophisticatedcore.upgrades.IOverflowResponseUpgrade;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.IUpgradeItem;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.IUpgradeWrapper;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler;
+import net.p3pp3rf1y.sophisticatedcore.util.DummySlot;
 import net.p3pp3rf1y.sophisticatedcore.util.NoopStorageWrapper;
 import org.jetbrains.annotations.NotNull;
 
@@ -1404,7 +1405,8 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 	@Override
 	public Slot getSlot(int slotId) {
 		if (slotId >= getInventorySlotsSize()) {
-			return upgradeSlots.get(slotId - getInventorySlotsSize());
+			int upgradeSlotId = slotId - getInventorySlotsSize();
+			return upgradeSlots.size() > upgradeSlotId ? upgradeSlots.get(upgradeSlotId) : DummySlot.INSTANCE;
 		} else {
 			return realInventorySlots.get(slotId);
 		}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/DummySlot.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/DummySlot.java
@@ -1,0 +1,28 @@
+package net.p3pp3rf1y.sophisticatedcore.util;
+
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+public class DummySlot extends Slot {
+	public static final DummySlot INSTANCE = new DummySlot();
+
+	private DummySlot() {
+		super(new SimpleContainer(0), -1, 0, 0);
+	}
+
+	@Override
+	public ItemStack getItem() {
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public void set(ItemStack p_40240_) {
+		//noop
+	}
+
+	@Override
+	public void setChanged() {
+		//noop
+	}
+}


### PR DESCRIPTION
…rld if player happens to press backpack open key at the same time they click the backpack out of slot causing client not having the backpack in slot when server had it and already started opening gui