### PR TITLE
fix: 🐛 Fixed scrollable inventory to only show slot background for sl…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedcore
 mod_group_id=sophisticatedcore
-mod_version=0.6.33
+mod_version=0.6.34
 sonar_project_key=sophisticatedcore:SophisticatedCore
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedCore
 
@@ -23,7 +23,7 @@ modrinth_project_id=nmoqTijg
 #deps
 jei_mc_version=1.20.1-forge
 jei_version=15.19.5.99
-jei_version_range=[15.19,)
+jei_version_range=[15.19.5.99,)
 patchouli_version=1.18.2-66
 balm_cf_file_id=4597440
 crafting_tweaks_cf_file_id=4596466

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/gui/SettingsScreen.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/gui/SettingsScreen.java
@@ -125,15 +125,14 @@ public abstract class SettingsScreen extends AbstractContainerScreen<SettingsCon
 		int y = (height - imageHeight) / 2;
 		StorageGuiHelper.renderStorageBackground(new Position(x, y), guiGraphics, storageBackgroundProperties.getTextureName(), imageWidth, getStorageInventoryHeight(getNumberOfVisibleRows()));
 		if (inventoryScrollPanel == null) {
-			drawSlotBg(guiGraphics, x, y);
+			drawSlotBg(guiGraphics, x, y, getMenu().getStorageInventorySlots().size());
 		}
 	}
 
-	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y) {
-		int inventorySlots = getMenu().getStorageInventorySlots().size();
+	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y, int visibleSlotsCount) {
 		int slotsOnLine = getSlotsOnLine();
-		int slotRows = inventorySlots / slotsOnLine;
-		int remainingSlots = inventorySlots % slotsOnLine;
+		int slotRows = visibleSlotsCount / slotsOnLine;
+		int remainingSlots = visibleSlotsCount % slotsOnLine;
 		GuiHelper.renderSlotsBackground(guiGraphics, x + StorageScreenBase.SLOTS_X_OFFSET, y + StorageScreenBase.SLOTS_Y_OFFSET, slotsOnLine, slotRows, remainingSlots);
 	}
 
@@ -288,8 +287,8 @@ public abstract class SettingsScreen extends AbstractContainerScreen<SettingsCon
 	}
 
 	@Override
-	public void drawSlotBg(GuiGraphics guiGraphics) {
-		drawSlotBg(guiGraphics, (width - imageWidth) / 2, (height - imageHeight) / 2);
+	public void drawSlotBg(GuiGraphics guiGraphics, int visibleSlotsCount) {
+		drawSlotBg(guiGraphics, (width - imageWidth) / 2, (height - imageHeight) / 2, visibleSlotsCount);
 	}
 
 	@Override

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/gui/StorageScreenBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/gui/StorageScreenBase.java
@@ -587,17 +587,16 @@ public abstract class StorageScreenBase<S extends StorageContainerMenuBase<?>> e
 		int y = (height - imageHeight) / 2;
 		drawInventoryBg(guiGraphics, x, y, storageBackgroundProperties.getTextureName());
 		if (inventoryScrollPanel == null) {
-			drawSlotBg(guiGraphics, x, y);
+			drawSlotBg(guiGraphics, x, y, getMenu().getNumberOfStorageInventorySlots());
 			drawSlotOverlays(guiGraphics);
 		}
 		drawUpgradeBackground(guiGraphics);
 	}
 
-	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y) {
-		int inventorySlots = getMenu().getNumberOfStorageInventorySlots();
+	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y, int visibleSlotsCount) {
 		int slotsOnLine = getSlotsOnLine();
-		int slotRows = inventorySlots / slotsOnLine;
-		int remainingSlots = inventorySlots % slotsOnLine;
+		int slotRows = visibleSlotsCount / slotsOnLine;
+		int remainingSlots = visibleSlotsCount % slotsOnLine;
 		GuiHelper.renderSlotsBackground(guiGraphics, x + StorageScreenBase.SLOTS_X_OFFSET, y + StorageScreenBase.SLOTS_Y_OFFSET, slotsOnLine, slotRows, remainingSlots);
 	}
 
@@ -1005,8 +1004,8 @@ public abstract class StorageScreenBase<S extends StorageContainerMenuBase<?>> e
 	}
 
 	@Override
-	public void drawSlotBg(GuiGraphics guiGraphics) {
-		drawSlotBg(guiGraphics, (width - imageWidth) / 2, (height - imageHeight) / 2);
+	public void drawSlotBg(GuiGraphics guiGraphics, int visibleSlotsCount) {
+		drawSlotBg(guiGraphics, (width - imageWidth) / 2, (height - imageHeight) / 2, visibleSlotsCount);
 		drawSlotOverlays(guiGraphics);
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/gui/controls/InventoryScrollPanel.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/gui/controls/InventoryScrollPanel.java
@@ -16,6 +16,9 @@ public class InventoryScrollPanel extends ScrollPanel {
 	private final int firstSlotIndex;
 	private final int numberOfSlots;
 	private final int slotsInARow;
+
+	private int visibleSlotsCount = 0;
+
 	public InventoryScrollPanel(Minecraft client, IInventoryScreen screen, int firstSlotIndex, int numberOfSlots, int slotsInARow, int height, int top, int left) {
 		super(client, slotsInARow * 18 + 6, height, top, left, 0);
 		this.screen = screen;
@@ -37,7 +40,7 @@ public class InventoryScrollPanel extends ScrollPanel {
 
 	@Override
 	protected void drawBackground(GuiGraphics guiGraphics, Tesselator tess, float partialTick) {
-		screen.drawSlotBg(guiGraphics);
+		screen.drawSlotBg(guiGraphics, visibleSlotsCount);
 	}
 
 	@Override
@@ -67,8 +70,10 @@ public class InventoryScrollPanel extends ScrollPanel {
 	public interface IInventoryScreen {
 		void renderInventorySlots(GuiGraphics guiGraphics, int mouseX, int mouseY, boolean canShowHover);
 
-		boolean isMouseOverSlot(Slot pSlot, double pMouseX, double pMouseY);
-		void drawSlotBg(GuiGraphics guiGraphics);
+		boolean isMouseOverSlot(Slot slot, double mouseX, double mouseY);
+
+		void drawSlotBg(GuiGraphics guiGraphics, int visibleSlotsCount);
+
 		int getTopY();
 
 		int getLeftX();
@@ -109,10 +114,13 @@ public class InventoryScrollPanel extends ScrollPanel {
 	}
 
 	public void updateSlotsYPosition() {
+		visibleSlotsCount = 0;
 		for (int i = firstSlotIndex, row = 0; i < firstSlotIndex + numberOfSlots; i++, row = i / slotsInARow) {
 			int newY = top - screen.getTopY() - (int) scrollDistance / 18 * 18 + row * 18 + TOP_Y_OFFSET;
-			if (newY < -17 || newY > height) {
+			if (newY < 1 || newY > height) {
 				newY = -100;
+			} else {
+				visibleSlotsCount++;
 			}
 			screen.getSlot(i).y = newY;
 		}


### PR DESCRIPTION
…ots that exist. Fixes an issue with gold double chest by default showing background for slots that are not there making it seem like there's a bug with inventory interaction.