### PR TITLE
fix: 🐛 Fixed handling of fluids that were removed from modpack in tan…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedcore
 mod_group_id=sophisticatedcore
-mod_version=0.7.5
+mod_version=0.7.6
 sonar_project_key=sophisticatedcore:SophisticatedCore
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedCore
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/IRenderedTankUpgrade.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/IRenderedTankUpgrade.java
@@ -40,7 +40,10 @@ public interface IRenderedTankUpgrade {
 
 		public static TankRenderInfo deserialize(CompoundTag tag) {
 			if (tag.contains(FLUID_TAG)) {
-				return new TankRenderInfo( FluidStack.loadFluidStackFromNBT(tag.getCompound(FLUID_TAG)), tag.getFloat(FILL_RATIO_TAG));
+				FluidStack contents = FluidStack.loadFluidStackFromNBT(tag.getCompound(FLUID_TAG));
+				if (!contents.isEmpty()) {
+					return new TankRenderInfo(contents, tag.getFloat(FILL_RATIO_TAG));
+				}
 			}
 
 			return new TankRenderInfo();

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/tank/TankUpgradeWrapper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/tank/TankUpgradeWrapper.java
@@ -101,8 +101,10 @@ public class TankUpgradeWrapper extends UpgradeWrapperBase<TankUpgradeWrapper, T
 	@Override
 	public void forceUpdateTankRenderInfo() {
 		TankRenderInfo renderInfo = new TankRenderInfo();
-		renderInfo.setFluid(contents);
-		renderInfo.setFillRatio((float) Math.round((float) contents.getAmount() / getTankCapacity() * 10) / 10);
+		if (!contents.isEmpty()) {
+			renderInfo.setFluid(contents);
+			renderInfo.setFillRatio((float) Math.round((float) contents.getAmount() / getTankCapacity() * 10) / 10);
+		}
 		updateTankRenderInfoCallback.accept(renderInfo);
 	}
 


### PR DESCRIPTION
…k upgrade so that it properly gets set as empty and doesn't crash in some cases