### PR TITLE
Fix EMI recipe tree highlights when no crafting upgrade is present

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/compat/recipeviewers/emi/EmiGridMenuInfo.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/compat/recipeviewers/emi/EmiGridMenuInfo.java
@@ -40,9 +40,12 @@ public class EmiGridMenuInfo<C extends StorageContainerMenuBase<?>> implements S
 
     @Override
     public List<Slot> getInputSources(C handler) {
-		List<Slot> slots = new ArrayList<>(handler.realInventorySlots.stream().filter(s -> s.mayPickup(Minecraft.getInstance().player)).toList());
-		slots.addAll(getCraftingSlots(handler));
-        return slots;
+		Optional<? extends UpgradeContainerBase<?, ?>> craftingContainer = handler.getOpenOrFirstCraftingContainer(recipeType);
+		return craftingContainer.map(craftingHandler -> {
+			List<Slot> slots = new ArrayList<>(handler.realInventorySlots.stream().filter(s -> s.mayPickup(Minecraft.getInstance().player)).toList());
+			slots.addAll(getCraftingSlots(handler));
+			return slots;
+		}).orElse(Collections.emptyList());
     }
 
     @Override


### PR DESCRIPTION
The code snippet from https://github.com/P3pp3rF1y/SophisticatedStorage/issues/674 that allows EMI to highlight slots when no crafting upgrade is installed.

This change should work for 1.20.x as well and I would appreciate it also getting merged there since the modpack I'm using that has this issue is on 1.20.1