### PR TITLE
Fix EMI counting storage inventory as player inventory (fixes #451)

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
@@ -67,6 +67,7 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 	public final NonNullList<ItemStack> remoteUpgradeSlots = NonNullList.create();
 	public final NonNullList<ItemStack> lastRealSlots = NonNullList.create();
 	public final List<Slot> realInventorySlots = Lists.newArrayList();
+	public final List<Slot> playerInventorySlots = Lists.newArrayList();
 	private final Map<Integer, UpgradeContainerBase<?, ?>> upgradeContainers = new LinkedHashMap<>();
 	private final NonNullList<ItemStack> remoteRealSlots = NonNullList.create();
 	protected final Player player;
@@ -230,6 +231,18 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 		return slot;
 	}
 
+	private Slot addPlayerInventorySlot(Slot slot) {
+		slot.index = getInventorySlotsSize();
+		slots.add(slot);
+		lastSlots.add(ItemStack.EMPTY);
+		remoteSlots.add(ItemStack.EMPTY);
+		realInventorySlots.add(slot);
+		lastRealSlots.add(ItemStack.EMPTY);
+		remoteRealSlots.add(ItemStack.EMPTY);
+		playerInventorySlots.add(slot);
+		return slot;
+	}
+
 	public int getInventorySlotsSize() {
 		return realInventorySlots.size();
 	}
@@ -328,7 +341,7 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 			slot = new Slot(playerInventory, slotIndex, 0, 0);
 		}
 
-		return addSlot(slot);
+		return addPlayerInventorySlot(slot);
 	}
 
 	public boolean hasSomethingMessedWithStorage() {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/compat/recipeviewers/emi/EmiGridMenuInfo.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/compat/recipeviewers/emi/EmiGridMenuInfo.java
@@ -40,7 +40,7 @@ public class EmiGridMenuInfo<C extends StorageContainerMenuBase<?>> implements S
 
     @Override
     public List<Slot> getInputSources(C handler) {
-		List<Slot> slots = new ArrayList<>(handler.realInventorySlots.stream().filter(s -> s.mayPickup(Minecraft.getInstance().player)).toList());
+		List<Slot> slots = new ArrayList<>(handler.playerInventorySlots);
 		slots.addAll(getCraftingSlots(handler));
         return slots;
     }


### PR DESCRIPTION
When a storage screen (SophisticatedBackpacks/SophisticatedStorage) is open, EMI's favorites menu incorrectly counts items inside the storage container as player inventory, causing inaccurate 'Missing' material counts.

Root cause: StorageContainerMenuBase.addSlot() mixes storage slots and player inventory slots in the same realInventorySlots list. EmiGridMenuInfo could not distinguish between them via mayPickup() filtering.

Fix: Introduce a separate playerInventorySlots list to track player inventory slots independently, and update EmiGridMenuInfo.getInputSources() to use this purified list.

   Fixes EMI incorrectly counting storage container items as player inventory when viewing the favorites menu. This resolves the
 "Missing" count being inaccurate while a SophisticatedCore storage screen is open.

   ## Related Issues

   - Fixes #451 (SophisticatedCore)
   - Related: https://github.com/emilyploszaj/emi/issues/1150