### PR TITLE
perf: directly access holder tags to avoid stream overhead and iterate item's tags instead of `tagKeys` in `anyTagMatches`

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/mixin/Holder$ReferenceAccessor.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/mixin/Holder$ReferenceAccessor.java
@@ -1,0 +1,16 @@
+package net.p3pp3rf1y.sophisticatedcore.mixin;
+
+import net.minecraft.core.Holder;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Set;
+
+@Mixin(Holder.Reference.class)
+public interface Holder$ReferenceAccessor {
+	// Provides direct access to the underlying Set in order to avoid Stream overhead. Do not mutate this set.
+	@Accessor
+	Set<TagKey<Item>> getTags();
+}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/FilterLogic.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/FilterLogic.java
@@ -14,10 +14,7 @@ import net.p3pp3rf1y.sophisticatedcore.util.InventoryHelper;
 import net.p3pp3rf1y.sophisticatedcore.util.ItemStackHelper;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
@@ -201,7 +198,8 @@ public class FilterLogic {
 	}
 
 	protected void initTags() {
-		tagKeys = new TreeSet<>(getAttributes().tagKeys());
+		tagKeys = new TreeSet<>(Comparator.comparing(TagKey::location));
+		tagKeys.addAll(getAttributes().tagKeys());
 	}
 
 	public void setAllowList(boolean isAllowList) {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/FilterLogic.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/FilterLogic.java
@@ -1,5 +1,6 @@
 package net.p3pp3rf1y.sophisticatedcore.upgrades;
 
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -8,6 +9,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemContainerContents;
 import net.neoforged.neoforge.registries.DeferredHolder;
+import net.p3pp3rf1y.sophisticatedcore.mixin.Holder$ReferenceAccessor;
 import net.p3pp3rf1y.sophisticatedcore.util.FilterItemStackHandler;
 import net.p3pp3rf1y.sophisticatedcore.util.InventoryHelper;
 import net.p3pp3rf1y.sophisticatedcore.util.ItemStackHelper;
@@ -18,8 +20,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class FilterLogic {
 	protected final ItemStack upgrade;
@@ -85,17 +85,17 @@ public class FilterLogic {
 	}
 
 	private boolean isTagMatch(ItemStack stack) {
+		var tags = ((Holder$ReferenceAccessor) stack.getItemHolder()).getTags();
 		if (shouldMatchAnyTag()) {
-			return anyTagMatches(stack.getTags());
+			return anyTagMatches(tags);
 		}
-		return allTagsMatch(stack.getTags());
+		return allTagsMatch(tags);
 	}
 
-	private boolean allTagsMatch(Stream<TagKey<Item>> tagsStream) {
+	private boolean allTagsMatch(Set<TagKey<Item>> tags) {
 		if (tagKeys == null) {
 			initTags();
 		}
-		Set<TagKey<Item>> tags = tagsStream.collect(Collectors.toSet());
 		for (TagKey<Item> tagName : tagKeys) {
 			if (!tags.contains(tagName)) {
 				return false;
@@ -104,11 +104,22 @@ public class FilterLogic {
 		return true;
 	}
 
-	private boolean anyTagMatches(Stream<TagKey<Item>> tags) {
+	private boolean anyTagMatches(Set<TagKey<Item>> tags) {
 		if (tagKeys == null) {
 			initTags();
 		}
-		return tags.anyMatch(t -> tagKeys.contains(t));
+
+		if (tags.isEmpty() || tagKeys.isEmpty()) {
+			return false;
+		}
+
+		for (var tagName : tagKeys) {
+			if (tags.contains(tagName)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	protected FilterAttributes getAttributes() {
@@ -188,8 +199,7 @@ public class FilterLogic {
 	}
 
 	protected void initTags() {
-		tagKeys = new TreeSet<>(Comparator.comparing(TagKey::location));
-		tagKeys.addAll(getAttributes().tagKeys());
+		tagKeys = new ObjectLinkedOpenHashSet<>(getAttributes().tagKeys());
 	}
 
 	public void setAllowList(boolean isAllowList) {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/FilterLogic.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/FilterLogic.java
@@ -1,6 +1,5 @@
 package net.p3pp3rf1y.sophisticatedcore.upgrades;
 
-import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -15,7 +14,10 @@ import net.p3pp3rf1y.sophisticatedcore.util.InventoryHelper;
 import net.p3pp3rf1y.sophisticatedcore.util.ItemStackHelper;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
@@ -199,7 +201,7 @@ public class FilterLogic {
 	}
 
 	protected void initTags() {
-		tagKeys = new ObjectLinkedOpenHashSet<>(getAttributes().tagKeys());
+		tagKeys = new TreeSet<>(getAttributes().tagKeys());
 	}
 
 	public void setAllowList(boolean isAllowList) {

--- a/src/main/resources/sophisticatedcore.mixins.json
+++ b/src/main/resources/sophisticatedcore.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.p3pp3rf1y.sophisticatedcore.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "Holder$ReferenceAccessor",
     "MixinAbstractContraptionEntity",
     "MixinVanillaInventoryCodeHooks"
   ],


### PR DESCRIPTION
<img width="1080" height="269" alt="image" src="https://github.com/user-attachments/assets/4425a12d-0e79-4288-a98d-237e88c372fd" />
