### PR TITLE
Fix IndexOutOfBoundsException in setRemoteSlot (bounds-check guards)

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
@@ -1043,9 +1043,16 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 	@Override
 	public void setRemoteSlot(int slotIndex, ItemStack stack) {
 		if (slotIndex < getInventorySlotsSize()) {
+			if (slotIndex < 0 || slotIndex >= remoteSlots.size()) {
+				return;
+			}
 			remoteSlots.set(slotIndex, stack.copy());
 		} else {
-			remoteUpgradeSlots.set(slotIndex - getInventorySlotsSize(), stack.copy());
+			int upgradeSlotIndex = slotIndex - getInventorySlotsSize();
+			if (upgradeSlotIndex < 0 || upgradeSlotIndex >= remoteUpgradeSlots.size()) {
+				return;
+			}
+			remoteUpgradeSlots.set(upgradeSlotIndex, stack.copy());
 		}
 	}
 


### PR DESCRIPTION
## Summary

`StorageContainerMenuBase#setRemoteSlot(int slotIndex, ItemStack stack)` is missing the bounds-check guards that its sibling `setRemoteSlotNoCopy(int, ItemStack)` already has. Under a container resize / click-packet desync race, the client can send a `slotIndex` that is negative or out-of-range for the current `remoteSlots` / `remoteUpgradeSlots`, and the call propagates straight into `NonNullList.set`, throwing `IndexOutOfBoundsException` and disconnecting the player.

## Stack trace (production, 2026-06-24)

```
java.lang.IndexOutOfBoundsException: Index -4 out of bounds for length 19
    at java.util.ArrayList.set(ArrayList.java:470)
    at net.minecraft.core.NonNullList.set(NonNullList.java:54)
    at net.p3pp3rf1y.sophisticatedcore.common.gui.StorageContainerMenuBase.m_182414_(StorageContainerMenuBase.java:1001)
    at net.minecraft.server.network.ServerGamePacketListenerImpl.m_5914_(...)
```

Triggered by `ServerboundContainerClickPacket` → `menu.clicked(...)` → `setRemoteSlot(...)` during a container-state desync (player closed/opened/resized while a click was in flight).

## Production evidence

- Observed on Otherworld modpack server.
- 17 crash reports collected in a 4 h window on 2026-06-24 (17:53 – 18:44 UTC).
- All reports show the same call site and the same race condition (negative `slotIndex` from a click packet arriving after the menu's slot list shrunk).

## Where the guard already exists

The sibling method already protects itself:

```java
public void setRemoteSlotNoCopy(int slotIndex, ItemStack stack) {
    if (slotIndex < getInventorySlotsSize()) {
        if (slotIndex >= remoteSlots.size()) return;     // <-- guard
        ...
    } else {
        int upgradeSlotIndex = slotIndex - inventorySlotsBeforeClickHandled;
        if (upgradeSlotIndex < 0 || upgradeSlotIndex >= remoteUpgradeSlots.size()) return; // <-- guard
        remoteUpgradeSlots.set(upgradeSlotIndex, stack);
    }
}
```

## Suggested patch

Mirror those guards into `setRemoteSlot`:

```java
public void setRemoteSlot(int slotIndex, ItemStack stack) {
    if (slotIndex < getInventorySlotsSize()) {
        if (slotIndex < 0 || slotIndex >= remoteSlots.size()) return;
        remoteSlots.set(slotIndex, stack.copy());
    } else {
        int upgradeSlotIndex = slotIndex - getInventorySlotsSize();
        if (upgradeSlotIndex < 0 || upgradeSlotIndex >= remoteUpgradeSlots.size()) return;
        remoteUpgradeSlots.set(upgradeSlotIndex, stack.copy());
    }
}
```

Three added lines, no behavior change in the happy path, and consistent with the existing sibling.

Happy to open a PR if forks are welcome under the current license — otherwise feel free to apply the patch directly. Thanks for SophisticatedCore!
