### PR TITLE
[1.18.x] Fix inventory transfers, shared crafting and packed storage previews

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/render/ClientStorageContentsTooltip.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/client/render/ClientStorageContentsTooltip.java
@@ -83,12 +83,13 @@ public abstract class ClientStorageContentsTooltip implements ClientTooltipCompo
 			upgrades.clear();
 			tooltipLines.clear();
 			if (storageUuid != null) {
-				wrapper.onContentsNbtUpdated();
-				sortedContents = InventoryHelper.getCompactedStacksSortedByCount(wrapper.getInventoryHandler());
+				wrapper = refreshContentsWrapper(wrapper);
+				sortedContents = getContents(wrapper);
 				upgrades = new ArrayList<>(wrapper.getUpgradeHandler().getSlotWrappers().values());
 				addMultiplierTooltip(wrapper);
 				addFluidTooltip(wrapper);
 				addEnergyTooltip(wrapper);
+				addTooltipLines(wrapper, tooltipLines);
 			}
 			if (upgrades.isEmpty() && sortedContents.isEmpty()) {
 				tooltipLines.add(new TranslatableComponent(TranslationHelper.INSTANCE.translItemTooltip(STORAGE_ITEM) + ".empty").withStyle(ChatFormatting.YELLOW));
@@ -106,6 +107,19 @@ public abstract class ClientStorageContentsTooltip implements ClientTooltipCompo
 
 	protected boolean shouldRefreshContents() {
 		return ClientStorageContentsTooltip.shouldRefreshContents;
+	}
+
+	protected IStorageWrapper refreshContentsWrapper(IStorageWrapper wrapper) {
+		wrapper.onContentsNbtUpdated();
+		return wrapper;
+	}
+
+	protected List<ItemStack> getContents(IStorageWrapper wrapper) {
+		return InventoryHelper.getCompactedStacksSortedByCount(wrapper.getInventoryHandler());
+	}
+
+	protected void addTooltipLines(IStorageWrapper wrapper, List<Component> lines) {
+		//noop
 	}
 
 	private void calculateWidth() {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBase.java
@@ -7,7 +7,6 @@ import it.unimi.dsi.fastutil.ints.IntComparators;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
@@ -18,6 +17,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.SlotItemHandler;
 import net.p3pp3rf1y.sophisticatedcore.SophisticatedCore;
 import net.p3pp3rf1y.sophisticatedcore.api.IStorageWrapper;
@@ -64,7 +64,6 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 	protected final Player player;
 	protected final S storageWrapper;
 	protected final IStorageWrapper parentStorageWrapper;
-	private final Map<Integer, ItemStack> slotStacksToUpdate = new HashMap<>();
 	private final int storageItemSlotIndex;
 	private final boolean shouldLockStorageItemSlot;
 	private int storageItemSlotNumber = -1;
@@ -765,12 +764,13 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 
 	private void broadcastFullStateOf(NonNullList<ItemStack> lastSlotsCollection, List<Slot> slotsCollection, int slotIndexOffset) {
 		for (int i = 0; i < slotsCollection.size(); ++i) {
-			ItemStack itemstack = slotsCollection.get(i).getItem();
-			triggerSlotListeners(i, itemstack, itemstack::copy, lastSlotsCollection, slotIndexOffset);
+			Slot slot = slotsCollection.get(i);
+			ItemStack itemstack = slot.getItem();
+			triggerSlotListeners(i, itemstack, itemstack::copy, lastSlotsCollection, slotIndexOffset, slot);
 		}
 	}
 
-	protected void triggerSlotListeners(int stackIndex, ItemStack slotStack, Supplier<ItemStack> slotStackCopy, NonNullList<ItemStack> lastSlotsCollection, int slotIndexOffset) {
+	protected void triggerSlotListeners(int stackIndex, ItemStack slotStack, Supplier<ItemStack> slotStackCopy, NonNullList<ItemStack> lastSlotsCollection, int slotIndexOffset, Slot slot) {
 		ItemStack itemstack = lastSlotsCollection.get(stackIndex);
 		if (!ItemStack.matches(itemstack, slotStack)) {
 			boolean clientStackChanged = !slotStack.equals(itemstack, true);
@@ -781,6 +781,10 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 				for (ContainerListener containerlistener : containerListeners) {
 					containerlistener.slotChanged(this, stackIndex + slotIndexOffset, stackCopy);
 				}
+			}
+
+			if (isUpgradeSettingsSlot(slot.index)) {
+				slot.setChanged(); //updating slots in upgrade tabs to trigger related logic like updating recipe result on another player's screen
 			}
 		}
 	}
@@ -1066,13 +1070,13 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 				if (itemstack4.isEmpty()) {
 					if (slot2.mayPickup(player)) {
 						if (slotStack.getCount() <= slotStack.getMaxStackSize()) {
-							inventory.setItem(dragType, slotStack);
+							inventory.setItem(dragType, slotStack.copy());
 							onSwapCraft(slot2, slotStack.getCount());
 							slot2.set(ItemStack.EMPTY);
 							slot2.onTake(player, slotStack);
 						} else {
-							inventory.setItem(dragType, slotStack.split(slotStack.getMaxStackSize()));
-							slot2.setChanged();
+							inventory.setItem(dragType, ItemHandlerHelper.copyStackWithSize(slotStack, slotStack.getMaxStackSize()));
+							slot2.set(ItemHandlerHelper.copyStackWithSize(slotStack, slotStack.getCount() - slotStack.getMaxStackSize()));
 						}
 					}
 				} else if (slotStack.isEmpty()) {
@@ -1094,9 +1098,10 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 							player.drop(slotStack, true);
 						}
 					} else {
+						ItemStack slotStackCopy = slotStack.copy();
 						slot2.set(itemstack4);
-						inventory.setItem(dragType, slotStack);
-						slot2.onTake(player, slotStack);
+						inventory.setItem(dragType, slotStackCopy);
+						slot2.onTake(player, slotStackCopy);
 					}
 				}
 			}
@@ -1154,8 +1159,6 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 				}
 			}
 		}
-
-		sendSlotUpdates();
 	}
 
 	@Override
@@ -1165,14 +1168,6 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 		}
 
 		return super.canTakeItemForPickAll(pStack, slot);
-	}
-
-	public void sendSlotUpdates() {
-		if (!player.level.isClientSide) {
-			ServerPlayer serverPlayer = (ServerPlayer) player;
-			slotStacksToUpdate.forEach((slot, stack) -> serverPlayer.connection.send(new ClientboundContainerSetSlotPacket(serverPlayer.containerMenu.containerId, incrementStateId(), slot, stack)));
-			slotStacksToUpdate.clear();
-		}
 	}
 
 	@Override
@@ -1434,9 +1429,10 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 
 	private void broadcastChangesIn(NonNullList<ItemStack> lastSlotsCollection, NonNullList<ItemStack> remoteSlotsCollection, List<Slot> slotsCollection, int slotIndexOffset) {
 		for (int i = 0; i < slotsCollection.size(); ++i) {
-			ItemStack itemstack = slotsCollection.get(i).getItem();
+			Slot slot = slotsCollection.get(i);
+			ItemStack itemstack = slot.getItem();
 			Supplier<ItemStack> supplier = Suppliers.memoize(itemstack::copy);
-			triggerSlotListeners(i, itemstack, supplier, lastSlotsCollection, slotIndexOffset);
+			triggerSlotListeners(i, itemstack, supplier, lastSlotsCollection, slotIndexOffset, slot);
 			synchronizeSlotToRemote(i, itemstack, supplier, remoteSlotsCollection, slotIndexOffset);
 		}
 	}
@@ -1502,10 +1498,6 @@ public abstract class StorageContainerMenuBase<S extends IStorageWrapper> extend
 
 	private boolean isInventorySlotInUpgradeTab(Player player, Slot slot) {
 		return slot.mayPickup(player) && !(slot instanceof ResultSlot);
-	}
-
-	public void setSlotStackToUpdate(int slot, ItemStack stack) {
-		slotStacksToUpdate.put(slot, stack);
 	}
 
 	private void reloadUpgradeControl() {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/compat/jei/CraftingContainerRecipeTransferHandlerServer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/compat/jei/CraftingContainerRecipeTransferHandlerServer.java
@@ -4,6 +4,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.p3pp3rf1y.sophisticatedcore.common.gui.StorageContainerMenuBase;
 
 import javax.annotation.Nullable;
@@ -48,15 +49,17 @@ public class CraftingContainerRecipeTransferHandlerServer {
 
 		putIntoInventory(player, inventorySlots, container, clearedCraftingItems);
 
-		container.sendSlotUpdates();
 		container.broadcastChanges();
 	}
 
 	private static void putIntoInventory(Player player, List<Integer> inventorySlots, StorageContainerMenuBase<?> container, List<ItemStack> clearedCraftingItems) {
 		for (ItemStack oldCraftingItem : clearedCraftingItems) {
 			int added = addStack(container, inventorySlots, oldCraftingItem);
-			if (added < oldCraftingItem.getCount() && !player.getInventory().add(oldCraftingItem)) {
-				player.drop(oldCraftingItem, false);
+			if (added < oldCraftingItem.getCount()) {
+				ItemStack remainingStack = added == 0 ? oldCraftingItem : ItemHandlerHelper.copyStackWithSize(oldCraftingItem, oldCraftingItem.getCount() - added);
+				if (!player.getInventory().add(remainingStack)) {
+					player.drop(remainingStack, false);
+				}
 			}
 		}
 	}
@@ -71,7 +74,7 @@ public class CraftingContainerRecipeTransferHandlerServer {
 				continue;
 			}
 			if (craftingSlot.hasItem()) {
-				ItemStack craftingItem = craftingSlot.remove(Integer.MAX_VALUE);
+				ItemStack craftingItem = craftingSlot.remove(craftingSlot.getItem().getCount());
 				clearedCraftingItems.add(craftingItem);
 			}
 			ItemStack transferItem = toTransfer.get(craftingSlotNumberIndex);
@@ -224,11 +227,13 @@ public class CraftingContainerRecipeTransferHandlerServer {
 						// Enough space
 						if (space >= remain) {
 							inventoryStack.grow(remain);
+							slot.setChanged();
 							return stack.getCount();
 						}
 
 						// Not enough space
 						inventoryStack.setCount(maxStackSize);
+						slot.setChanged();
 
 						added += space;
 					}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/IInventoryPartHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/IInventoryPartHandler.java
@@ -34,11 +34,19 @@ public interface IInventoryPartHandler {
 		return ItemStack.EMPTY;
 	}
 
+	default ItemStack extractItemIgnoringLimit(int slot, int amount, boolean simulate) {
+		return extractItem(slot, amount, simulate);
+	}
+
 	default ItemStack insertItem(int slot, ItemStack stack, boolean simulate, TriFunction<Integer, ItemStack, Boolean, ItemStack> insertSuper) {
 		return stack;
 	}
 
 	default void setStackInSlot(int slot, ItemStack stack, BiConsumer<Integer, ItemStack> setStackInSlotSuper) {
+		//noop
+	}
+
+	default void onContentsChanged(int slot, BiConsumer<Integer, ItemStack> setStackInSlotSuper) {
 		//noop
 	}
 
@@ -55,6 +63,10 @@ public interface IInventoryPartHandler {
 	}
 
 	default int getSlots() { return 0;}
+
+	default boolean canCompact() {
+		return true;
+	}
 
 	String getName();
 
@@ -114,6 +126,11 @@ public interface IInventoryPartHandler {
 		@Override
 		public ItemStack extractItem(int slot, int amount, boolean simulate) {
 			return parent.extractItemInternal(slot, amount, simulate);
+		}
+
+		@Override
+		public ItemStack extractItemIgnoringLimit(int slot, int amount, boolean simulate) {
+			return parent.extractItemInternal(slot, amount, simulate, true);
 		}
 
 		@Override

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandler.java
@@ -88,6 +88,9 @@ public abstract class InventoryHandler extends ItemStackHandler implements ITrac
 	@Override
 	public void onContentsChanged(int slot) {
 		super.onContentsChanged(slot);
+		if (inventoryPartitioner != null) {
+			inventoryPartitioner.getPartBySlot(slot).onContentsChanged(slot, super::setStackInSlot);
+		}
 		if (persistent && updateSlotNbt(slot)) {
 			saveInventory();
 			triggerOnChangeListeners(slot);
@@ -219,7 +222,11 @@ public abstract class InventoryHandler extends ItemStackHandler implements ITrac
 	}
 
 	public ItemStack extractItemInternal(int slot, int amount, boolean simulate) {
-		if (amount == 0) {
+		return extractItemInternal(slot, amount, simulate, false);
+	}
+
+	ItemStack extractItemInternal(int slot, int amount, boolean simulate, boolean ignoreStackLimit) {
+		if (amount <= 0) {
 			return ItemStack.EMPTY;
 		}
 
@@ -230,7 +237,7 @@ public abstract class InventoryHandler extends ItemStackHandler implements ITrac
 			return ItemStack.EMPTY;
 		}
 
-		int toExtract = Math.min(amount, existing.getMaxStackSize());
+		int toExtract = Math.min(amount, ignoreStackLimit ? Integer.MAX_VALUE : existing.getMaxStackSize());
 
 		if (existing.getCount() <= toExtract) {
 			if (!simulate) {
@@ -252,6 +259,10 @@ public abstract class InventoryHandler extends ItemStackHandler implements ITrac
 	@Nonnull
 	public ItemStack extractItem(int slot, int amount, boolean simulate) {
 		return inventoryPartitioner.getPartBySlot(slot).extractItem(slot, amount, simulate);
+	}
+
+	public ItemStack extractItemIgnoringLimit(int slot, int amount, boolean simulate) {
+		return inventoryPartitioner.getPartBySlot(slot).extractItemIgnoringLimit(slot, amount, simulate);
 	}
 
 	@Override
@@ -483,6 +494,7 @@ public abstract class InventoryHandler extends ItemStackHandler implements ITrac
 		filterItemSlots.clear();
 		filterItemSlots.putAll(inventoryPartitioner.getFilterItems());
 
+		slotTracker.refreshSlotIndexesFrom(this);
 		filterItemsChangeListener.accept(filterItemSlots.keySet());
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandlerSlotTracker.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandlerSlotTracker.java
@@ -321,7 +321,7 @@ public class InventoryHandlerSlotTracker implements ISlotTracker {
 			while (!emptySlots.isEmpty() && i++ < sizeBefore) {
 				Iterator<Integer> it = emptySlots.iterator();
 				int slot = it.next();
-				while (memorySettings.isSlotSelected(slot)) {
+				while (memorySettings.isSlotSelected(slot) || isFilterSlot(slot)) {
 					if (!it.hasNext()) {
 						return remainingStack;
 					}
@@ -336,6 +336,15 @@ public class InventoryHandlerSlotTracker implements ISlotTracker {
 		}
 
 		return remainingStack;
+	}
+
+	private boolean isFilterSlot(int slot) {
+		for (Set<Integer> slots : filterItemSlots.values()) {
+			if (slots.contains(slot)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private ItemStack insertIntoEmptyFilterSlots(IItemHandlerInserter inserter, boolean simulate, ItemStack remainingStack) {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/settings/memory/MemorySettingsCategory.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/settings/memory/MemorySettingsCategory.java
@@ -91,10 +91,12 @@ public class MemorySettingsCategory implements ISettingsCategory<MemorySettingsC
 	}
 
 	public void unselectAllSlots() {
+		Set<Integer> slotIndexes = getSlotIndexes();
 		unselectAllFilterItemSlots();
 		unselectAllFilteStackSlots();
 
 		serializeFilterItems();
+		slotIndexes.forEach(getInventoryHandler()::onSlotFilterChanged);
 	}
 
 	private void unselectAllFilteStackSlots() {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/UpgradeHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/UpgradeHandler.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -347,7 +348,7 @@ public class UpgradeHandler extends ItemStackHandler {
 	}
 
 	private static class Accessor implements IUpgradeWrapperAccessor {
-		private final Map<Class<?>, List<?>> interfaceWrappers = new HashMap<>();
+		private final Map<Class<?>, List<?>> interfaceWrappers = new ConcurrentHashMap<>();
 
 		private final UpgradeHandler upgradeHandler;
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/compacting/CompactingUpgradeWrapper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/compacting/CompactingUpgradeWrapper.java
@@ -9,6 +9,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.p3pp3rf1y.sophisticatedcore.api.ISlotChangeResponseUpgrade;
 import net.p3pp3rf1y.sophisticatedcore.api.IStorageWrapper;
 import net.p3pp3rf1y.sophisticatedcore.inventory.IItemHandlerSimpleInserter;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.FilterLogic;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.IFilteredUpgrade;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.IInsertResponseUpgrade;
@@ -22,7 +23,9 @@ import net.p3pp3rf1y.sophisticatedcore.util.RecipeHelper.CompactingShape;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -30,6 +33,8 @@ public class CompactingUpgradeWrapper extends UpgradeWrapperBase<CompactingUpgra
 		implements IInsertResponseUpgrade, IFilteredUpgrade, ISlotChangeResponseUpgrade, ITickableUpgrade {
 	private final FilterLogic filterLogic;
 	private final Set<Integer> slotsToCompact = new HashSet<>();
+	private final Map<IItemHandlerSimpleInserter, Set<Integer>> pendingCompactingSlots = new IdentityHashMap<>();
+	private boolean isCompacting = false;
 
 	public CompactingUpgradeWrapper(IStorageWrapper storageWrapper, ItemStack upgrade, Consumer<ItemStack> upgradeSaveHandler) {
 		super(storageWrapper, upgrade, upgradeSaveHandler);
@@ -49,6 +54,32 @@ public class CompactingUpgradeWrapper extends UpgradeWrapperBase<CompactingUpgra
 	}
 
 	private void compactSlot(IItemHandlerSimpleInserter inventoryHandler, int slot) {
+		if (!canCompactSlot(inventoryHandler, slot)) {
+			return;
+		}
+		pendingCompactingSlots.computeIfAbsent(inventoryHandler, h -> new HashSet<>()).add(slot);
+		if (isCompacting) {
+			return;
+		}
+		isCompacting = true;
+		try {
+			while (!pendingCompactingSlots.isEmpty()) {
+				IItemHandlerSimpleInserter handler = pendingCompactingSlots.keySet().iterator().next();
+				Set<Integer> pendingSlots = pendingCompactingSlots.remove(handler);
+				for (int pendingSlot : pendingSlots) {
+					compactSlotContents(handler, pendingSlot);
+				}
+			}
+		} finally {
+			pendingCompactingSlots.clear();
+			isCompacting = false;
+		}
+	}
+
+	private void compactSlotContents(IItemHandlerSimpleInserter inventoryHandler, int slot) {
+		if (!canCompactSlot(inventoryHandler, slot)) {
+			return;
+		}
 		ItemStack slotStack = inventoryHandler.getStackInSlot(slot);
 
 		if (slotStack.isEmpty() || slotStack.hasTag() || !filterLogic.matchesFilter(slotStack)) {
@@ -70,7 +101,7 @@ public class CompactingUpgradeWrapper extends UpgradeWrapperBase<CompactingUpgra
 		int totalCount = width * height;
 		RecipeHelper.CompactingResult compactingResult = RecipeHelper.getCompactingResult(item, width, height);
 		if (!compactingResult.getResult().isEmpty()) {
-			ItemStack extractedStack = InventoryHelper.extractFromInventory(item, totalCount, inventoryHandler, true);
+			ItemStack extractedStack = extractIngredients(item, totalCount, inventoryHandler, true);
 			if (extractedStack.getCount() != totalCount) {
 				return;
 			}
@@ -82,12 +113,27 @@ public class CompactingUpgradeWrapper extends UpgradeWrapperBase<CompactingUpgra
 				if (!fitsResultAndRemainingItems(inventoryHandler, remainingItemsCopy, resultCopy)) {
 					break;
 				}
-				InventoryHelper.extractFromInventory(item, totalCount, inventoryHandler, false);
+				extractIngredients(item, totalCount, inventoryHandler, false);
 				inventoryHandler.insertItem(resultCopy, false);
 				InventoryHelper.insertIntoInventory(remainingItemsCopy, inventoryHandler, false);
-				extractedStack = InventoryHelper.extractFromInventory(item, totalCount, inventoryHandler, true);
+				extractedStack = extractIngredients(item, totalCount, inventoryHandler, true);
 			}
 		}
+	}
+
+	private boolean canCompactSlot(IItemHandler inventory, int slot) {
+		return !(inventory instanceof InventoryHandler handler) || handler.getInventoryPartitioner().getPartBySlot(slot).canCompact();
+	}
+
+	private ItemStack extractIngredients(Item item, int count, IItemHandler inventory, boolean simulate) {
+		int extracted = 0;
+		for (int slot = 0; slot < inventory.getSlots() && extracted < count; slot++) {
+			ItemStack stack = inventory.getStackInSlot(slot);
+			if (canCompactSlot(inventory, slot) && stack.getItem() == item && !stack.hasTag()) {
+				extracted += inventory.extractItem(slot, count - extracted, simulate).getCount();
+			}
+		}
+		return new ItemStack(item, extracted);
 	}
 
 	private boolean fitsResultAndRemainingItems(IItemHandler inventoryHandler, List<ItemStack> remainingItems, ItemStack result) {
@@ -135,10 +181,10 @@ public class CompactingUpgradeWrapper extends UpgradeWrapperBase<CompactingUpgra
 			return;
 		}
 
-		for (int slot : slotsToCompact) {
+		Set<Integer> pendingSlots = new HashSet<>(slotsToCompact);
+		slotsToCompact.clear();
+		for (int slot : pendingSlots) {
 			compactSlot(storageWrapper.getInventoryHandler(), slot);
 		}
-
-		slotsToCompact.clear();
 	}
 }

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/crafting/CraftingUpgradeContainer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/crafting/CraftingUpgradeContainer.java
@@ -15,7 +15,6 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.p3pp3rf1y.sophisticatedcore.common.gui.ICraftingContainer;
 import net.p3pp3rf1y.sophisticatedcore.common.gui.SlotSuppliedHandler;
-import net.p3pp3rf1y.sophisticatedcore.common.gui.StorageContainerMenuBase;
 import net.p3pp3rf1y.sophisticatedcore.common.gui.UpgradeContainerBase;
 import net.p3pp3rf1y.sophisticatedcore.common.gui.UpgradeContainerType;
 import net.p3pp3rf1y.sophisticatedcore.util.NBTHelper;
@@ -78,10 +77,6 @@ public class CraftingUpgradeContainer extends UpgradeContainerBase<CraftingUpgra
 							player.drop(itemstack1, false);
 						}
 					}
-					if (thePlayer.containerMenu instanceof StorageContainerMenuBase<?> storageContainerMenu) {
-						Slot slot = slots.get(i);
-						storageContainerMenu.setSlotStackToUpdate(slot.index, slot.getItem());
-					}
 				}
 
 				if (!remainingStack.isEmpty()) {
@@ -123,9 +118,6 @@ public class CraftingUpgradeContainer extends UpgradeContainerBase<CraftingUpgra
 			}
 
 			craftingResultSlot.set(itemstack);
-			if (serverplayerentity.containerMenu instanceof StorageContainerMenuBase<?> storageContainerMenu) {
-				storageContainerMenu.setSlotStackToUpdate(craftingResultSlot.index, itemstack);
-			}
 		}
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/InventoryHelper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/util/InventoryHelper.java
@@ -17,6 +17,7 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 import net.p3pp3rf1y.sophisticatedcore.inventory.IItemHandlerSimpleInserter;
 import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
 import net.p3pp3rf1y.sophisticatedcore.inventory.ItemStackKey;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.IPickupResponseUpgrade;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler;
@@ -281,7 +282,8 @@ public class InventoryHelper {
 		if (slot >= itemHandler.getSlots()) {
 			return ItemStack.EMPTY;
 		}
-		return itemHandler.extractItem(slot, itemHandler.getStackInSlot(slot).getCount(), false);
+		int count = itemHandler.getStackInSlot(slot).getCount();
+		return itemHandler instanceof InventoryHandler handler ? handler.extractItemIgnoringLimit(slot, count, false) : itemHandler.extractItem(slot, count, false);
 	}
 
 	public static void insertOrDropItem(Player player, ItemStack stack, IItemHandler... inventories) {

--- a/src/test/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBaseTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedcore/common/gui/StorageContainerMenuBaseTest.java
@@ -1,0 +1,86 @@
+package net.p3pp3rf1y.sophisticatedcore.common.gui;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.NonNullList;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.Mockito.*;
+
+class StorageContainerMenuBaseTest {
+	@BeforeAll
+	static void setup() throws Exception {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+		try (MockedStatic<ObfuscationReflectionHelper> reflection = mockStatic(ObfuscationReflectionHelper.class)) {
+			Method method = Slot.class.getDeclaredMethod("onSwapCraft", int.class);
+			method.setAccessible(true);
+			reflection.when(() -> ObfuscationReflectionHelper.findMethod(Slot.class, "m_6405_", int.class)).thenReturn(method);
+			Class.forName(StorageContainerMenuBase.class.getName());
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {32, 1000})
+	void hotbarExtractionDoesNotShareTheMutableSlotStack(int count) {
+		StorageContainerMenuBase<?> menu = mock(StorageContainerMenuBase.class, CALLS_REAL_METHODS);
+		Player player = mock(Player.class);
+		Inventory inventory = mock(Inventory.class);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.getItem(0)).thenReturn(ItemStack.EMPTY);
+		Slot slot = mock(Slot.class);
+		ItemStack contents = new ItemStack(Items.IRON_INGOT, count);
+		when(slot.getItem()).thenReturn(contents);
+		when(slot.mayPickup(player)).thenReturn(true);
+		doReturn(slot).when(menu).getSlot(0);
+		doAnswer(i -> {
+			contents.setCount(((ItemStack) i.getArgument(0)).getCount());
+			return null;
+		}).when(slot).set(any(ItemStack.class));
+
+		menu.doClick(0, 0, ClickType.SWAP, player);
+
+		ArgumentCaptor<ItemStack> taken = ArgumentCaptor.forClass(ItemStack.class);
+		verify(inventory).setItem(eq(0), taken.capture());
+		assertEquals(Math.min(count, 64), taken.getValue().getCount());
+		assertEquals(count, taken.getValue().getCount() + contents.getCount());
+		assertNotSame(contents, taken.getValue());
+	}
+
+	@Test
+	void anotherPlayersGridChangeRefreshesUpgradeSlotsOnce() throws Exception {
+		StorageContainerMenuBase<?> menu = mock(StorageContainerMenuBase.class, CALLS_REAL_METHODS);
+		Field listeners = AbstractContainerMenu.class.getDeclaredField("containerListeners");
+		listeners.setAccessible(true);
+		listeners.set(menu, List.of());
+		Slot craftingSlot = mock(Slot.class);
+		craftingSlot.index = 42;
+		doReturn(true).when(menu).isUpgradeSettingsSlot(42);
+		NonNullList<ItemStack> previous = NonNullList.withSize(1, new ItemStack(Items.IRON_INGOT));
+
+		menu.triggerSlotListeners(0, ItemStack.EMPTY, () -> ItemStack.EMPTY, previous, 42, craftingSlot);
+		verify(craftingSlot).setChanged();
+
+		menu.triggerSlotListeners(0, ItemStack.EMPTY, () -> ItemStack.EMPTY, previous, 42, craftingSlot);
+		verify(craftingSlot, times(1)).setChanged();
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedcore/compat/jei/CraftingContainerRecipeTransferHandlerServerTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedcore/compat/jei/CraftingContainerRecipeTransferHandlerServerTest.java
@@ -1,0 +1,90 @@
+package net.p3pp3rf1y.sophisticatedcore.compat.jei;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.p3pp3rf1y.sophisticatedcore.common.gui.StorageContainerMenuBase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class CraftingContainerRecipeTransferHandlerServerTest {
+	@BeforeAll
+	static void setup() throws Exception {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+		try (MockedStatic<ObfuscationReflectionHelper> reflection = mockStatic(ObfuscationReflectionHelper.class)) {
+			Method method = Slot.class.getDeclaredMethod("onSwapCraft", int.class);
+			method.setAccessible(true);
+			reflection.when(() -> ObfuscationReflectionHelper.findMethod(Slot.class, "m_6405_", int.class)).thenReturn(method);
+			Class.forName(StorageContainerMenuBase.class.getName());
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource({"50, true", "50, false", "60, true", "60, false"})
+	void recipeReplacementSavesAcceptedItemsAndReturnsRemainder(int storedCount, boolean playerHasSpace) throws Exception {
+		StorageContainerMenuBase<?> menu = mock(StorageContainerMenuBase.class);
+		SimpleContainer contents = new SimpleContainer(3);
+		contents.setItem(0, new ItemStack(Items.IRON_INGOT, 10));
+		contents.setItem(1, new ItemStack(Items.IRON_INGOT, storedCount));
+		contents.setItem(2, new ItemStack(Items.DIAMOND, 64));
+		contents.getItem(2).grow(1);
+		AtomicInteger savedIronCount = new AtomicInteger(storedCount);
+		contents.addListener(changedContents -> savedIronCount.set(changedContents.getItem(1).getCount()));
+
+		Slot grid = spy(new Slot(contents, 0, 0, 0));
+		List<Slot> slots = List.of(grid, new Slot(contents, 1, 0, 0), new Slot(contents, 2, 0, 0));
+		Field inventorySlotsField = StorageContainerMenuBase.class.getField("realInventorySlots");
+		inventorySlotsField.setAccessible(true);
+		inventorySlotsField.set(menu, slots);
+		Field upgradeSlotsField = StorageContainerMenuBase.class.getField("upgradeSlots");
+		upgradeSlotsField.setAccessible(true);
+		upgradeSlotsField.set(menu, List.of());
+		when(menu.getSlot(anyInt())).thenAnswer(i -> slots.get(i.getArgument(0)));
+
+		Player player = mock(Player.class);
+		Inventory inventory = mock(Inventory.class);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.add(any(ItemStack.class))).thenReturn(playerHasSpace);
+		player.containerMenu = menu;
+
+		CraftingContainerRecipeTransferHandlerServer.setItems(player, Map.of(0, 2), List.of(0), List.of(1, 2), true);
+
+		assertEquals(64, contents.getItem(0).getCount());
+		assertTrue(contents.getItem(0).is(Items.DIAMOND));
+		assertEquals(Math.min(64, storedCount + 10), contents.getItem(1).getCount());
+		assertEquals(contents.getItem(1).getCount(), savedIronCount.get());
+		assertEquals(1, contents.getItem(2).getCount());
+		if (storedCount + 10 > 64) {
+			ArgumentCaptor<ItemStack> remainder = ArgumentCaptor.forClass(ItemStack.class);
+			verify(inventory).add(remainder.capture());
+			assertEquals(storedCount + 10 - 64, remainder.getValue().getCount());
+			assertTrue(remainder.getValue().is(Items.IRON_INGOT));
+			verify(player, times(playerHasSpace ? 0 : 1)).drop(remainder.getValue(), false);
+		} else {
+			verify(inventory, never()).add(any(ItemStack.class));
+			verify(player, never()).drop(any(ItemStack.class), anyBoolean());
+		}
+		verify(grid).remove(10);
+		verify(grid, never()).remove(Integer.MAX_VALUE);
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandlerSlotTrackerTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandlerSlotTrackerTest.java
@@ -1,0 +1,79 @@
+package net.p3pp3rf1y.sophisticatedcore.inventory;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.p3pp3rf1y.sophisticatedcore.settings.memory.MemorySettingsCategory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+class InventoryHandlerSlotTrackerTest {
+	@BeforeAll
+	static void setup() throws Exception {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+		try (MockedStatic<ObfuscationReflectionHelper> reflection = mockStatic(ObfuscationReflectionHelper.class)) {
+			Field field = ItemStack.class.getDeclaredField("capNBT");
+			field.setAccessible(true);
+			reflection.when(() -> ObfuscationReflectionHelper.findField(ItemStack.class, "capNBT")).thenReturn(field);
+			Class.forName(ItemStackKey.class.getName());
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void fallbackSkipsBothFilterAndMemorySlots(boolean simulate) {
+		InventoryHandler handler = mock(InventoryHandler.class);
+		when(handler.getSlots()).thenReturn(3);
+		when(handler.getStackInSlot(anyInt())).thenReturn(ItemStack.EMPTY);
+		MemorySettingsCategory memory = mock(MemorySettingsCategory.class);
+		when(memory.isSlotSelected(1)).thenReturn(true);
+		InventoryHandlerSlotTracker tracker = new InventoryHandlerSlotTracker(memory, Map.of(Items.IRON_INGOT, Set.of(0)));
+		tracker.refreshSlotIndexesFrom(handler);
+		List<Integer> insertedSlots = new ArrayList<>();
+		ItemStack stack = new ItemStack(Items.DIAMOND, 32);
+
+		ItemStack remainder = tracker.insertItemIntoHandler(handler, (slot, inserted, simulation) -> {
+			assertEquals(simulate, simulation);
+			insertedSlots.add(slot);
+			return ItemStack.EMPTY;
+		}, s -> s, stack, simulate);
+
+		assertTrue(remainder.isEmpty());
+		assertEquals(List.of(2), insertedSlots);
+		assertEquals(32, stack.getCount());
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void reservedSlotsReturnUnmatchedItemsAndAcceptTheirFilter(boolean simulate) {
+		InventoryHandler handler = mock(InventoryHandler.class);
+		when(handler.getSlots()).thenReturn(1);
+		when(handler.getStackInSlot(0)).thenReturn(ItemStack.EMPTY);
+		InventoryHandlerSlotTracker tracker = new InventoryHandlerSlotTracker(mock(MemorySettingsCategory.class), Map.of(Items.IRON_INGOT, Set.of(0)));
+		tracker.refreshSlotIndexesFrom(handler);
+		ItemStack unmatched = new ItemStack(Items.DIAMOND, 32);
+
+		assertSame(unmatched, tracker.insertItemIntoHandler(handler, (slot, stack, simulation) -> {
+			fail("Unmatched items reached a reserved slot");
+			return ItemStack.EMPTY;
+		}, s -> s, unmatched, simulate));
+		assertTrue(tracker.insertItemIntoHandler(handler, (slot, stack, simulation) -> ItemStack.EMPTY, s -> s, new ItemStack(Items.IRON_INGOT), simulate).isEmpty());
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandlerTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedcore/inventory/InventoryHandlerTest.java
@@ -1,0 +1,45 @@
+package net.p3pp3rf1y.sophisticatedcore.inventory;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class InventoryHandlerTest {
+	@BeforeAll
+	static void setup() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	void internalExtractionCanExceedStackSizeWithoutChangingCapabilityExtraction() {
+		AtomicReference<ItemStack> contents = new AtomicReference<>(new ItemStack(Items.IRON_INGOT, 1000));
+		InventoryHandler handler = mock(InventoryHandler.class, CALLS_REAL_METHODS);
+		doNothing().when(handler).validateSlotIndex(0);
+		doAnswer(i -> contents.get()).when(handler).getSlotStack(0);
+		doAnswer(i -> {
+			contents.set(i.getArgument(1));
+			return null;
+		}).when(handler).setSlotStack(eq(0), any(ItemStack.class));
+		IInventoryPartHandler part = new IInventoryPartHandler.Default(handler, 1);
+
+		assertEquals(64, part.extractItem(0, 900, true).getCount());
+		assertEquals(900, part.extractItemIgnoringLimit(0, 900, true).getCount());
+		assertEquals(1000, contents.get().getCount());
+
+		assertEquals(900, part.extractItemIgnoringLimit(0, 900, false).getCount());
+		assertEquals(100, contents.get().getCount());
+		assertTrue(part.extractItemIgnoringLimit(0, -1, false).isEmpty());
+		assertEquals(100, part.extractItemIgnoringLimit(0, Integer.MAX_VALUE, false).getCount());
+		assertTrue(contents.get().isEmpty());
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedcore/upgrades/UpgradeHandlerTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedcore/upgrades/UpgradeHandlerTest.java
@@ -1,0 +1,52 @@
+package net.p3pp3rf1y.sophisticatedcore.upgrades;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class UpgradeHandlerTest {
+	@Test
+	void accessorSupportsOverlappingCacheMisses() throws Exception {
+		UpgradeHandler handler = mock(UpgradeHandler.class);
+		Constructor<?> constructor = Class.forName(UpgradeHandler.class.getName() + "$Accessor").getDeclaredConstructor(UpgradeHandler.class);
+		constructor.setAccessible(true);
+		IUpgradeWrapperAccessor accessor = (IUpgradeWrapperAccessor) constructor.newInstance(handler);
+
+		CountDownLatch lookupStarted = new CountDownLatch(1);
+		CountDownLatch otherLookupFinished = new CountDownLatch(1);
+		when(handler.getListOfWrappersThatImplement(Runnable.class)).thenAnswer(i -> {
+			lookupStarted.countDown();
+			assertTrue(otherLookupFinished.await(5, TimeUnit.SECONDS));
+			return List.of();
+		});
+		when(handler.getListOfWrappersThatImplement(AutoCloseable.class)).thenReturn(List.of());
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<List<Runnable>> first = executor.submit(() -> accessor.getWrappersThatImplement(Runnable.class));
+			assertTrue(lookupStarted.await(5, TimeUnit.SECONDS));
+			assertTrue(accessor.getWrappersThatImplement(AutoCloseable.class).isEmpty());
+			otherLookupFinished.countDown();
+			assertTrue(first.get(5, TimeUnit.SECONDS).isEmpty());
+			assertSame(accessor.getWrappersThatImplement(Runnable.class), accessor.getWrappersThatImplementFromMainStorage(Runnable.class));
+			verify(handler).getListOfWrappersThatImplement(Runnable.class);
+
+			accessor.clearCache();
+			accessor.getWrappersThatImplement(Runnable.class);
+			verify(handler, times(2)).getListOfWrappersThatImplement(Runnable.class);
+		} finally {
+			otherLookupFinished.countDown();
+			executor.shutdownNow();
+		}
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedcore/upgrades/compacting/CompactingUpgradeWrapperTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedcore/upgrades/compacting/CompactingUpgradeWrapperTest.java
@@ -1,0 +1,159 @@
+package net.p3pp3rf1y.sophisticatedcore.upgrades.compacting;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.items.ItemStackHandler;
+import net.p3pp3rf1y.sophisticatedcore.api.IStorageWrapper;
+import net.p3pp3rf1y.sophisticatedcore.inventory.IInventoryPartHandler;
+import net.p3pp3rf1y.sophisticatedcore.inventory.IItemHandlerSimpleInserter;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryPartitioner;
+import net.p3pp3rf1y.sophisticatedcore.util.RecipeHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class CompactingUpgradeWrapperTest {
+	@BeforeAll
+	static void setup() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	private CompactingUpgradeWrapper getWrapper(IStorageWrapper storage) {
+		CompactingUpgradeItem item = mock(CompactingUpgradeItem.class);
+		when(item.getFilterSlotCount()).thenReturn(1);
+		when(item.shouldCompactThreeByThree()).thenReturn(true);
+		ItemStack upgrade = mock(ItemStack.class);
+		when(upgrade.getItem()).thenReturn(item);
+		CompoundTag tag = new CompoundTag();
+		when(upgrade.getTag()).thenReturn(tag);
+		when(upgrade.getOrCreateTag()).thenReturn(tag);
+		return new CompactingUpgradeWrapper(storage, upgrade, s -> {});
+	}
+
+	@Test
+	void chainedCompactingDoesNotReenterInventoryInsertion() throws Exception {
+		try (MockedStatic<RecipeHelper> recipes = mockStatic(RecipeHelper.class)) {
+			recipes.when(() -> RecipeHelper.getItemCompactingShapes(any(Item.class))).thenReturn(Set.of(RecipeHelper.CompactingShape.NONE));
+			Constructor<RecipeHelper.CompactingResult> constructor = RecipeHelper.CompactingResult.class.getDeclaredConstructor(ItemStack.class, List.class);
+			constructor.setAccessible(true);
+			Item[] chain = {Items.IRON_NUGGET, Items.IRON_INGOT, Items.IRON_BLOCK};
+			for (int i = 0; i < 2; i++) {
+				Item ingredient = chain[i];
+				RecipeHelper.CompactingResult result = constructor.newInstance(new ItemStack(chain[i + 1]), List.of());
+				recipes.when(() -> RecipeHelper.getItemCompactingShapes(ingredient)).thenReturn(Set.of(RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+				recipes.when(() -> RecipeHelper.getCompactingResult(ingredient, 3, 3)).thenReturn(result);
+			}
+
+			CompactingUpgradeWrapper wrapper = getWrapper(mock(IStorageWrapper.class));
+			CompactingInventory inventory = new CompactingInventory();
+			inventory.setStackInSlot(0, new ItemStack(Items.IRON_NUGGET, 162));
+			inventory.afterInsert = slot -> wrapper.onAfterInsert(inventory, slot);
+
+			wrapper.onAfterInsert(inventory, 0);
+
+			int blocks = 0;
+			for (int slot = 0; slot < inventory.getSlots(); slot++) {
+				ItemStack stack = inventory.getStackInSlot(slot);
+				assertTrue(stack.isEmpty() || stack.is(Items.IRON_BLOCK));
+				blocks += stack.getCount();
+			}
+			assertEquals(2, blocks);
+			assertEquals(1, inventory.maxInsertionDepth);
+		}
+	}
+
+	@Test
+	void compactingOrdinarySlotsDoesNotExtractFromCompressionSlots() throws Exception {
+		try (MockedStatic<RecipeHelper> recipes = mockStatic(RecipeHelper.class)) {
+			recipes.when(() -> RecipeHelper.getItemCompactingShapes(Items.IRON_NUGGET)).thenReturn(Set.of(RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+			Constructor<RecipeHelper.CompactingResult> constructor = RecipeHelper.CompactingResult.class.getDeclaredConstructor(ItemStack.class, List.class);
+			constructor.setAccessible(true);
+			RecipeHelper.CompactingResult result = constructor.newInstance(new ItemStack(Items.IRON_INGOT), List.of());
+			recipes.when(() -> RecipeHelper.getCompactingResult(Items.IRON_NUGGET, 3, 3)).thenReturn(result);
+			InventoryHandler inventory = mock(InventoryHandler.class);
+			InventoryPartitioner partitioner = mock(InventoryPartitioner.class);
+			when(inventory.getInventoryPartitioner()).thenReturn(partitioner);
+			when(inventory.getSlots()).thenReturn(2);
+			when(partitioner.getPartBySlot(0)).thenReturn(mock(IInventoryPartHandler.class));
+			when(partitioner.getPartBySlot(1)).thenReturn(() -> "default");
+			when(inventory.getStackInSlot(0)).thenReturn(new ItemStack(Items.IRON_NUGGET, 81));
+			ItemStack ordinarySlot = new ItemStack(Items.IRON_NUGGET, 9);
+			when(inventory.getStackInSlot(1)).thenReturn(ordinarySlot);
+			when(inventory.extractItem(eq(1), anyInt(), anyBoolean())).thenAnswer(i -> {
+				int count = Math.min(ordinarySlot.getCount(), i.getArgument(1));
+				if (!(boolean) i.getArgument(2)) {
+					ordinarySlot.shrink(count);
+				}
+				return new ItemStack(Items.IRON_NUGGET, count);
+			});
+			when(inventory.insertItem(any(ItemStack.class), anyBoolean())).thenReturn(ItemStack.EMPTY);
+
+			getWrapper(mock(IStorageWrapper.class)).onAfterInsert(inventory, 1);
+
+			verify(inventory, never()).extractItem(eq(0), anyInt(), anyBoolean());
+			verify(inventory).insertItem(argThat(stack -> stack.is(Items.IRON_INGOT) && stack.getCount() == 1), eq(false));
+			assertTrue(ordinarySlot.isEmpty());
+		}
+	}
+
+	@Test
+	void skipsPartsThatManageTheirOwnCompacting() {
+		InventoryHandler inventory = mock(InventoryHandler.class);
+		InventoryPartitioner partitioner = mock(InventoryPartitioner.class);
+		IInventoryPartHandler part = mock(IInventoryPartHandler.class);
+		when(inventory.getInventoryPartitioner()).thenReturn(partitioner);
+		when(partitioner.getPartBySlot(0)).thenReturn(part);
+
+		getWrapper(mock(IStorageWrapper.class)).onAfterInsert(inventory, 0);
+
+		verify(inventory, never()).getStackInSlot(anyInt());
+	}
+
+	private static class CompactingInventory extends ItemStackHandler implements IItemHandlerSimpleInserter {
+		private IntConsumer afterInsert = slot -> {};
+		private int insertionDepth = 0;
+		private int maxInsertionDepth = 0;
+
+		private CompactingInventory() {
+			super(3);
+		}
+
+		@Override
+		public ItemStack insertItem(ItemStack stack, boolean simulate) {
+			for (int slot = 0; slot < getSlots() && !stack.isEmpty(); slot++) {
+				stack = insertItem(slot, stack, simulate);
+			}
+			return stack;
+		}
+
+		@Override
+		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+			insertionDepth++;
+			maxInsertionDepth = Math.max(maxInsertionDepth, insertionDepth);
+			try {
+				ItemStack remainder = super.insertItem(slot, stack, simulate);
+				if (!simulate && remainder.getCount() < stack.getCount()) {
+					afterInsert.accept(slot);
+				}
+				return remainder;
+			} finally {
+				insertionDepth--;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This addresses item duplication, item loss and stale inventory state on 1.18.2, and supplies the inventory and tooltip hooks used by the companion SophisticatedStorage changes.

We still use 1.18.2 and ran into these issues in our pack. I'm sharing the fixes in case they are useful, with no expectation that you resume maintenance or publish another 1.18.2 release.

Companion PR: [**[1.18.x] Fix compression handling, packed barrel tooltips and display rendering**](https://github.com/P3pp3rF1y/SophisticatedStorage/pull/927) in SophisticatedStorage. The compression changes should be reviewed together.

### Backported fixes

- **Number-key transfers:** copy stacks when extracting or swapping through the hotbar so modifying a displayed compression stack does not duplicate its contents. Also notify inventory parts when their contents change. Adapted from [e33028eb](https://github.com/P3pp3rF1y/SophisticatedCore/commit/e33028eb1ccf876377bd853776ee764038f19c91).
- **JEI recipe replacement:** return only the portion of the old crafting ingredients that storage could not accept. Remove the actual crafting-slot count rather than requesting `Integer.MAX_VALUE`. Adapted from [1f852d7e](https://github.com/P3pp3rF1y/SophisticatedCore/commit/1f852d7e3ffc7019be720ff2439534ac167a52ce) and [b53a9503](https://github.com/P3pp3rF1y/SophisticatedCore/commit/b53a9503967944ec98cbeec8c6f8e948a0a18ae2).
- **Shared crafting upgrades:** refresh the crafting result for other players when upgrade slots change, and remove the old explicit slot-update queue. This prevents another player from taking a stale result. Adapted from [897380eb](https://github.com/P3pp3rF1y/SophisticatedCore/commit/897380eb9c650cef5f49081d5d94ee96f0f040ed).
- **Reserved inventory slots:** refresh slot indexes when filters change and skip both memory-reserved and filter-reserved slots during general insertion. Adapted from [55b60f2c](https://github.com/P3pp3rF1y/SophisticatedCore/commit/55b60f2c08dffb3702184341486df02466ce5e10).
- **Upgrade accessor cache:** use `ConcurrentHashMap` for interface-wrapper lookups to address concurrent modification crashes. Adapted from [cfda82fa](https://github.com/P3pp3rF1y/SophisticatedCore/commit/cfda82fad7a8896132a54498019b23364467353b).

### Additional fixes

- **JEI persistence:** notify the slot after growing or filling an existing stack. Previously the GUI could show the accepted ingredients while saved inventory data still contained the old count, losing those items on reload.
- **Clearing memory settings:** notify affected inventory parts after clearing all reservations. An emptied compression barrel can then accept a different material after being unlocked.
- **Compacting callbacks:** queue changes raised during compacting and process them after the current operation. Preserve changes queued during tick processing, and exclude compression-managed slots from both compacting and ingredient extraction.
- **Internal extraction:** add an explicit extraction path without the normal stack-size cap for operations that need to remove a whole stored stack. Ordinary inventory extraction keeps its existing cap.
- **Packed previews:** add hooks to refresh the preview wrapper, supply its displayed contents and append tooltip lines. Storage uses these for packed barrel denominations, upgrades and tier information.

### Validation

Core builds successfully and all 69 tests pass. Checks cover inventory conservation, reserved slots, compacting callbacks, cache access and crafting updates.

In-game checks with the companion Storage build covered number-key transfers, hopper insertion, unlocking empty barrels, two players sharing a crafting upgrade, and JEI recipe replacement. The final JEI persistence check exercised both 50 → 60 and 60 → 64 stored ingots with available and full player inventories. Saved data and reopened barrels retained the correct counts; the six-item remainder was returned or dropped correctly.

Versions are unchanged.
